### PR TITLE
Add .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,10 @@
+language: go
+
+go:
+  - 1.7.x
+  - 1.8.x
+  - master
+
+matrix:
+  allow_failures:
+  - go: master


### PR DESCRIPTION
So we have confidence that the service still works when merging pull
requests.

I've included Go 1.7 since we say it's supported in the README.md.

Allow failures from Go's `master` branch in case the breakage is from
upstream.