### PR TITLE
Support Alertmanager >=0.6.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ string.
 To use alertmanager2es, you'll need:
 
 - an [Elasticsearch][] cluster
-- [Alertmanager][]
+- [Alertmanager][] 0.6.0 or above
 
 To build alertmanager2es, you'll need:
 

--- a/main.go
+++ b/main.go
@@ -198,18 +198,8 @@ type notification struct {
 	Receiver          string            `json:"receiver"`
 	Status            string            `json:"status"`
 	Version           string            `json:"version"`
-
-	// Elasticsearch can't cope with unsigned integers, so convert groupKey
-	// to a string using a custom type
-	// Overrides notify.WebhookMessage.GroupKey
-	GroupKey groupKey `json:"groupKey"`
+	GroupKey          string            `json:"groupKey"`
 
 	// Timestamp records when the alert notification was received
 	Timestamp string `json:"@timestamp"`
-}
-
-type groupKey uint64
-
-func (g *groupKey) MarshalJSON() ([]byte, error) {
-	return []byte(fmt.Sprintf(`"%d"`, *g)), nil
 }

--- a/main_test.go
+++ b/main_test.go
@@ -143,7 +143,7 @@ var amNotification = []byte(`{
 	"receiver": "alertmanager2es",
 	"status": "firing",
 	"version": "3",
-	"groupKey": 13493306413933147611
+	"groupKey": "{}/{}/{notify=\"default\":{alertname=\"Foo_Bar\", instance=\"foo\"}"
 }`)
 
-var esDocument = []byte(`{"alerts":[{"annotations":{"link":"https://example.com/Foo+Bar","summary":"Alert summary"},"endsAt":"0001-01-01T00:00:00Z","generatorURL":"https://example.com","labels":{"alertname":"Foo_Bar","instance":"foo"},"startsAt":"2017-02-02T16:51:13.507955756Z","status":"firing"}],"commonAnnotations":{"link":"https://example.com/Foo+Bar","summary":"Alert summary"},"commonLabels":{"alertname":"Foo_Bar","instance":"foo"},"externalURL":"https://alertmanager.example.com","groupLabels":{"alertname":"Foo_Bar"},"receiver":"alertmanager2es","status":"firing","version":"3","groupKey":"13493306413933147611","@timestamp":"2017-02-02T19:37:22+01:00"}`)
+var esDocument = []byte(`{"alerts":[{"annotations":{"link":"https://example.com/Foo+Bar","summary":"Alert summary"},"endsAt":"0001-01-01T00:00:00Z","generatorURL":"https://example.com","labels":{"alertname":"Foo_Bar","instance":"foo"},"startsAt":"2017-02-02T16:51:13.507955756Z","status":"firing"}],"commonAnnotations":{"link":"https://example.com/Foo+Bar","summary":"Alert summary"},"commonLabels":{"alertname":"Foo_Bar","instance":"foo"},"externalURL":"https://alertmanager.example.com","groupLabels":{"alertname":"Foo_Bar"},"receiver":"alertmanager2es","status":"firing","version":"3","groupKey":"{}/{}/{notify=\"default\":{alertname=\"Foo_Bar\", instance=\"foo\"}","@timestamp":"2017-02-02T19:37:22+01:00"}`)


### PR DESCRIPTION
Alertmanager 0.6.0 API was changed and groupKey is no longer an int, see https://github.com/prometheus/alertmanager/pull/725

```
$ go/src/github.com/cloudflare/alertmanager2es$ make test
go test 
2017/05/08 12:55:43 POST to Elasticsearch on "http://127.0.0.1:35137/alertmanager-2017.05/alert_group" returned HTTP 404:  404 page not found
PASS
ok  	github.com/cloudflare/alertmanager2es	0.005s
```