### PR TITLE
Add Content-Type header to HTTP requests

### DIFF
--- a/main.go
+++ b/main.go
@@ -155,6 +155,7 @@ func handler(w http.ResponseWriter, r *http.Request) {
 	}
 
 	req.Header.Set("User-Agent", versionString)
+	req.Header.Set("Content-Type", "application/json")
 
 	resp, err := http.DefaultClient.Do(req)
 	if err != nil {


### PR DESCRIPTION
Elasticsearch 6.0 and above enforces the presence of the Content-Type header in
all incoming requests [1].

[1] http://bit.ly/2GaOVX9