### PR TITLE
Pezzak's basic auth fixes, option to skip SSL verification, README.md corrections

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,18 +103,17 @@ sending data:
 
 ```json
 {
-  "template": "alertmanager-2*",
-  "settings": {
-    "number_of_shards": 1,
-    "number_of_replicas": 1,
-    "index.refresh_interval": "10s",
-    "index.query.default_field": "groupLabels.alertname"
-  },
-  "mappings": {
-    "_default_": {
-      "_all": {
-        "enabled": false
-      },
+  "index_patterns": [
+    "alertmanager-2*"
+  ],
+  "template": {
+    "settings": {
+      "number_of_shards": 1,
+      "number_of_replicas": 1,
+      "index.refresh_interval": "10s",
+      "index.query.default_field": "groupLabels.alertname"
+    },
+    "mappings": {
       "properties": {
         "@timestamp": {
           "type": "date",
@@ -127,10 +126,8 @@ sending data:
             "match": "*",
             "match_mapping_type": "string",
             "mapping": {
-              "type": "string",
-              "index": "not_analyzed",
-              "ignore_above": 1024,
-              "doc_values": true
+              "type": "text",
+              "ignore_above": 2048
             }
           }
         }

--- a/main.go
+++ b/main.go
@@ -64,7 +64,7 @@ func main() {
 	flag.StringVar(&esURL, "esURL", esURL, "Elasticsearch HTTP URL")
 	flag.BoolVar(&showVersion, "version", false, "Print version number and exit")
 	flag.Parse()
-
+	
 	if showVersion {
 		fmt.Println(versionString)
 		os.Exit(0)
@@ -156,6 +156,13 @@ func handler(w http.ResponseWriter, r *http.Request) {
 
 	req.Header.Set("User-Agent", versionString)
 	req.Header.Set("Content-Type", "application/json")
+
+	esUser := os.Getenv("ES_USER")
+	esPass := os.Getenv("ES_PASS")
+
+	if len(esUser) != 0 && len(esPass) != 0 {
+		req.SetBasicAuth(esUser, esPass)
+	}
 
 	resp, err := http.DefaultClient.Do(req)
 	if err != nil {


### PR DESCRIPTION
This PR includes pezzak's commits from the following PR:
https://github.com/cloudflare/alertmanager2es/pull/15

Also:
- Fixed all issues there;
- Added option to skip SSL verification for elasticsearch nodes with self-signed SSL certs;
- Updated index template in the README.md